### PR TITLE
Remove DoSelect from sponsors and increase image size of docker and npm #11

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -662,13 +662,10 @@
             <br>
             <div class="">
                 <div class="row">
-                    <div class="col m2 offset-m3 sponsor">
-                        <a href="http://doselect.com"><img class="responsive-img" src="img/doselect.png" ></a>
-                    </div>
-                    <div class="col m2 sponsor">
+                    <div class="col m3 offset-m3 sponsor">
                         <a href="http://docker.com"><img class="responsive-img" src="img/docker.png" ></a>
                     </div>
-                    <div class="col m2 sponsor">
+                    <div class="col m3 sponsor">
                         <a href="http://npmjs.com"><img class="responsive-img" src="img/npm.png" ></a>
                     </div>
 
@@ -728,20 +725,12 @@
             </div>
             <div class="row">
                 <div class="col s6 center">
-                    <a href="http://doselect.com"><img style="width: 100px;" class="responsive-img" src="img/doselect.png" ></a>
-                </div>
-                <div class="col s6 center">
                     <a href="http://docker.com"><img style="width: 100px;" class="responsive-img" src="img/docker.png" ></a>
                 </div>
-            </div>
-            <div class="row">
                 <div class="col s6 center">
                     <a href="http://npmjs.com"><img style="width: 100px;" class="responsive-img" src="img/npm.png" ></a>
                 </div>
-                <div class="col s4">
-                </div>
             </div>
-
         </div>
 
     </div>


### PR DESCRIPTION
Fixes issue #11 Remove DoSelect from sponsors and increase image size of docker and npm

Changes: Remove DoSelect from sponsors and increase image size of docker and npm

Screenshots for the change:
![image](https://user-images.githubusercontent.com/1074428/31573537-3bfe9ca6-b0e8-11e7-9c46-e633fd9a5800.png)

